### PR TITLE
Momentum Decay

### DIFF
--- a/src/stores/__tests__/userPreferences.spec.ts
+++ b/src/stores/__tests__/userPreferences.spec.ts
@@ -42,6 +42,11 @@ describe("userPreferences store", () => {
       expect(store.notificationLevels).toBeNull();
     });
 
+    it("should initialize with null momentumDecay", () => {
+      const store = useUserPreferencesStore();
+      expect(store.momentumDecay).toBeNull();
+    });
+
     it("should initialize with loading false", () => {
       const store = useUserPreferencesStore();
       expect(store.loading).toBe(false);
@@ -199,6 +204,65 @@ describe("userPreferences store", () => {
       expect(store.defaultFill).toBe(FillStyle.ShadeFill);
       expect(store.notificationLevels).toEqual(["info", "warning"]);
     });
+
+    it("should load momentum decay when provided", async () => {
+      mockLoadUserPreferences.mockResolvedValue({
+        momentumDecay: 10
+      });
+
+      const store = useUserPreferencesStore();
+      await store.load();
+
+      expect(store.momentumDecay).toBe(10);
+    });
+
+    it("should default momentum decay to 3 when not provided", async () => {
+      mockLoadUserPreferences.mockResolvedValue({
+        defaultFill: FillStyle.PlainFill
+      });
+
+      const store = useUserPreferencesStore();
+      await store.load();
+
+      expect(store.momentumDecay).toBe(3);
+    });
+
+    it("should load momentum decay of 0", async () => {
+      mockLoadUserPreferences.mockResolvedValue({
+        momentumDecay: 0
+      });
+
+      const store = useUserPreferencesStore();
+      await store.load();
+
+      expect(store.momentumDecay).toBe(0);
+    });
+
+    it("should load momentum decay at maximum value 60", async () => {
+      mockLoadUserPreferences.mockResolvedValue({
+        momentumDecay: 60
+      });
+
+      const store = useUserPreferencesStore();
+      await store.load();
+
+      expect(store.momentumDecay).toBe(60);
+    });
+
+    it("should load all preferences together", async () => {
+      mockLoadUserPreferences.mockResolvedValue({
+        defaultFill: FillStyle.ShadeFill,
+        notificationLevels: ["info", "warning"],
+        momentumDecay: 15
+      });
+
+      const store = useUserPreferencesStore();
+      await store.load();
+
+      expect(store.defaultFill).toBe(FillStyle.ShadeFill);
+      expect(store.notificationLevels).toEqual(["info", "warning"]);
+      expect(store.momentumDecay).toBe(15);
+    });
   });
 
   describe("save function", () => {
@@ -210,7 +274,8 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        notificationLevels: null
+        notificationLevels: null,
+        momentumDecay: null
       });
     });
 
@@ -222,7 +287,8 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        notificationLevels: null
+        notificationLevels: null,
+        momentumDecay: null
       });
     });
 
@@ -246,7 +312,8 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.NoFill,
-        notificationLevels: null
+        notificationLevels: null,
+        momentumDecay: null
       });
 
       // Test PlainFill
@@ -254,7 +321,8 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        notificationLevels: null
+        notificationLevels: null,
+        momentumDecay: null
       });
 
       // Test ShadeFill
@@ -262,7 +330,8 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.ShadeFill,
-        notificationLevels: null
+        notificationLevels: null,
+        momentumDecay: null
       });
     });
 
@@ -274,7 +343,8 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        notificationLevels: ["success", "error"]
+        notificationLevels: ["success", "error"],
+        momentumDecay: null
       });
     });
 
@@ -286,7 +356,8 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        notificationLevels: []
+        notificationLevels: [],
+        momentumDecay: null
       });
     });
 
@@ -299,7 +370,62 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        notificationLevels: ["info", "warning"]
+        notificationLevels: ["info", "warning"],
+        momentumDecay: null
+      });
+    });
+
+    it("should save momentum decay preference", async () => {
+      const store = useUserPreferencesStore();
+      store.momentumDecay = 20;
+
+      await store.save();
+
+      expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
+        defaultFill: null,
+        notificationLevels: null,
+        momentumDecay: 20
+      });
+    });
+
+    it("should save momentum decay of 0", async () => {
+      const store = useUserPreferencesStore();
+      store.momentumDecay = 0;
+
+      await store.save();
+
+      expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
+        defaultFill: null,
+        notificationLevels: null,
+        momentumDecay: 0
+      });
+    });
+
+    it("should save momentum decay at maximum value 60", async () => {
+      const store = useUserPreferencesStore();
+      store.momentumDecay = 60;
+
+      await store.save();
+
+      expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
+        defaultFill: null,
+        notificationLevels: null,
+        momentumDecay: 60
+      });
+    });
+
+    it("should save all preferences together", async () => {
+      const store = useUserPreferencesStore();
+      store.defaultFill = FillStyle.PlainFill;
+      store.notificationLevels = ["info", "warning"];
+      store.momentumDecay = 25;
+
+      await store.save();
+
+      expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
+        defaultFill: FillStyle.PlainFill,
+        notificationLevels: ["info", "warning"],
+        momentumDecay: 25
       });
     });
   });
@@ -323,7 +449,8 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        notificationLevels: ["success", "info", "error", "warning"]
+        notificationLevels: ["success", "info", "error", "warning"],
+        momentumDecay: 3
       });
     });
 
@@ -354,7 +481,8 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        notificationLevels: ["success", "info", "error", "warning"]
+        notificationLevels: ["success", "info", "error", "warning"],
+        momentumDecay: 3
       });
 
       // Verify value unchanged
@@ -379,7 +507,8 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        notificationLevels: ["error", "warning"]
+        notificationLevels: ["error", "warning"],
+        momentumDecay: 3
       });
     });
 
@@ -396,7 +525,8 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenLastCalledWith("test-user-123", {
         defaultFill: null,
-        notificationLevels: ["success", "error", "warning"]
+        notificationLevels: ["success", "error", "warning"],
+        momentumDecay: 3
       });
 
       // Add it back
@@ -404,7 +534,60 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenLastCalledWith("test-user-123", {
         defaultFill: null,
-        notificationLevels: ["success", "info", "error", "warning"]
+        notificationLevels: ["success", "info", "error", "warning"],
+        momentumDecay: 3
+      });
+    });
+
+    it("should handle momentum decay workflow", async () => {
+      mockLoadUserPreferences.mockResolvedValue({
+        momentumDecay: 10
+      });
+
+      const store = useUserPreferencesStore();
+      
+      // Load initial preference
+      await store.load();
+      expect(store.momentumDecay).toBe(10);
+
+      // Modify preference
+      store.momentumDecay = 30;
+
+      // Save modified preference
+      await store.save();
+      expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
+        defaultFill: null,
+        notificationLevels: ["success", "info", "error", "warning"],
+        momentumDecay: 30
+      });
+    });
+
+    it("should handle all preferences workflow together", async () => {
+      mockLoadUserPreferences.mockResolvedValue({
+        defaultFill: FillStyle.PlainFill,
+        notificationLevels: ["success", "info"],
+        momentumDecay: 15
+      });
+
+      const store = useUserPreferencesStore();
+      
+      // Load all preferences
+      await store.load();
+      expect(store.defaultFill).toBe(FillStyle.PlainFill);
+      expect(store.notificationLevels).toEqual(["success", "info"]);
+      expect(store.momentumDecay).toBe(15);
+
+      // Modify all preferences
+      store.defaultFill = FillStyle.ShadeFill;
+      store.notificationLevels = ["error", "warning"];
+      store.momentumDecay = 45;
+
+      // Save all modified preferences
+      await store.save();
+      expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
+        defaultFill: FillStyle.ShadeFill,
+        notificationLevels: ["error", "warning"],
+        momentumDecay: 45
       });
     });
   });

--- a/src/stores/__tests__/userPreferences.spec.ts
+++ b/src/stores/__tests__/userPreferences.spec.ts
@@ -330,10 +330,12 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        momentumDecay: null
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -346,9 +348,12 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
+        momentumDecay: null,
         easelDecimalPrecision: 4,
         hierarchyDecimalPrecision: 5,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -360,10 +365,12 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        momentumDecay: null
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -387,10 +394,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.NoFill,
-        momentumDecay: null
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
 
       // Test PlainFill
@@ -398,10 +407,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        momentumDecay: null
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
 
       // Test ShadeFill
@@ -409,10 +420,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.ShadeFill,
-        momentumDecay: null
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -425,9 +438,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
+        momentumDecay: null,
         easelDecimalPrecision: 0,
         hierarchyDecimalPrecision: 0,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
 
       // Test high use case
@@ -436,9 +452,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
 
       // Test max number
@@ -447,9 +466,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
+        momentumDecay: null,
         easelDecimalPrecision: Number.MAX_VALUE,
         hierarchyDecimalPrecision: Number.MAX_VALUE,
-        notificationLevels: null
+        notificationLevels: null,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -461,10 +483,12 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        momentumDecay: null
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: ["success", "error"]
+        notificationLevels: ["success", "error"],
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -476,10 +500,12 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        momentumDecay: null
+        momentumDecay: null,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: []
+        notificationLevels: [],
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -493,7 +519,11 @@ describe("userPreferences store", () => {
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
         notificationLevels: ["info", "warning"],
-        momentumDecay: null
+        momentumDecay: null,
+        easelDecimalPrecision: 3,
+        hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -506,7 +536,11 @@ describe("userPreferences store", () => {
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
         notificationLevels: null,
-        momentumDecay: 20
+        momentumDecay: 20,
+        easelDecimalPrecision: 3,
+        hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -519,7 +553,11 @@ describe("userPreferences store", () => {
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
         notificationLevels: null,
-        momentumDecay: 0
+        momentumDecay: 0,
+        easelDecimalPrecision: 3,
+        hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -532,7 +570,11 @@ describe("userPreferences store", () => {
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
         notificationLevels: null,
-        momentumDecay: 60
+        momentumDecay: 60,
+        easelDecimalPrecision: 3,
+        hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -546,10 +588,12 @@ describe("userPreferences store", () => {
 
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        momentumDecay: 25
+        momentumDecay: 25,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: ["info", "warning"]
+        notificationLevels: ["info", "warning"],
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
   });
@@ -575,10 +619,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        momentumDecay: 3
+        momentumDecay: 3,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: ["success", "info", "error", "warning"]
+        notificationLevels: ["success", "info", "error", "warning"],
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -609,10 +655,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.PlainFill,
-        momentumDecay: 3
+        momentumDecay: 3,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: ["success", "info", "error", "warning"]
+        notificationLevels: ["success", "info", "error", "warning"],
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
 
       // Verify value unchanged
@@ -637,10 +685,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
-        momentumDecay: 3
+        momentumDecay: 3,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: ["error", "warning"]
+        notificationLevels: ["error", "warning"],
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -657,10 +707,12 @@ describe("userPreferences store", () => {
       await store.save();
       expect(mockSaveUserPreferences).toHaveBeenLastCalledWith("test-user-123", {
         defaultFill: null,
-        momentumDecay: 3
+        momentumDecay: 3,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
-        notificationLevels: ["success", "error", "warning"]
+        notificationLevels: ["success", "error", "warning"],
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
 
       // Add it back
@@ -669,7 +721,11 @@ describe("userPreferences store", () => {
       expect(mockSaveUserPreferences).toHaveBeenLastCalledWith("test-user-123", {
         defaultFill: null,
         notificationLevels: ["success", "info", "error", "warning"],
-        momentumDecay: 3
+        momentumDecay: 3,
+        easelDecimalPrecision: 3,
+        hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -692,7 +748,11 @@ describe("userPreferences store", () => {
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: null,
         notificationLevels: ["success", "info", "error", "warning"],
-        momentumDecay: 30
+        momentumDecay: 30,
+        easelDecimalPrecision: 3,
+        hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
 
@@ -700,7 +760,11 @@ describe("userPreferences store", () => {
       mockLoadUserPreferences.mockResolvedValue({
         defaultFill: FillStyle.PlainFill,
         notificationLevels: ["success", "info"],
-        momentumDecay: 15
+        momentumDecay: 15,
+        easelDecimalPrecision: 3,
+        hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
 
       const store = useUserPreferencesStore();
@@ -721,9 +785,11 @@ describe("userPreferences store", () => {
       expect(mockSaveUserPreferences).toHaveBeenCalledWith("test-user-123", {
         defaultFill: FillStyle.ShadeFill,
         notificationLevels: ["error", "warning"],
-        momentumDecay: 45
+        momentumDecay: 45,
         easelDecimalPrecision: 3,
         hierarchyDecimalPrecision: 3,
+        boundaryColor: "#000000FF",
+        boundaryWidth: 4
       });
     });
   });

--- a/src/stores/se.ts
+++ b/src/stores/se.ts
@@ -923,6 +923,8 @@ export const useSEStore = defineStore("se", () => {
       updateDisabledTools("expression");
     }
   }
+
+  
   //#region rotateSphere
   function rotateSphere(rotationMat: Matrix4): void {
     // Update the inverseTotalRotationMatrix. We have a new rotationMat which is transforming by

--- a/src/stores/userPreferences.ts
+++ b/src/stores/userPreferences.ts
@@ -57,7 +57,7 @@ export const useUserPreferencesStore = defineStore("userPreferences", () => {
       hierarchyDecimalPrecision: hierarchyDecimalPrecision.value,
       notificationLevels: notificationLevels.value,
       boundaryColor: boundaryColor.value,
-      boundaryWidth: boundaryWidth.value
+      boundaryWidth: boundaryWidth.value,
       momentumDecay: momentumDecay.value
     });
   }

--- a/src/stores/userPreferences.ts
+++ b/src/stores/userPreferences.ts
@@ -10,6 +10,7 @@ const DEFAULT_NOTIFICATION_LEVELS = ["success", "info", "error", "warning"];
 export const useUserPreferencesStore = defineStore("userPreferences", () => {
   const defaultFill = ref<FillStyle | null>(null);
   const notificationLevels = ref<string[] | null>(null);
+  const momentumDecay = ref<number | null>(null);
   const loading = ref(false);
 
   async function load(uid?: string) {
@@ -25,6 +26,8 @@ export const useUserPreferencesStore = defineStore("userPreferences", () => {
     }
     // Load notification levels, defaulting to all types if not set
     notificationLevels.value = prefs?.notificationLevels ?? [...DEFAULT_NOTIFICATION_LEVELS];
+    // Load momentum decay, defaulting to 3 seconds if not set
+    momentumDecay.value = prefs?.momentumDecay ?? 3;
     loading.value = false;
   }
 
@@ -35,9 +38,10 @@ export const useUserPreferencesStore = defineStore("userPreferences", () => {
     // Persist the current value (allow null to be stored as null)
     await saveUserPreferences(uid, { 
       defaultFill: defaultFill.value,
-      notificationLevels: notificationLevels.value
+      notificationLevels: notificationLevels.value,
+      momentumDecay: momentumDecay.value
     });
   }
 
-  return { defaultFill, notificationLevels, loading, load, save };
+  return { defaultFill, notificationLevels, momentumDecay, loading, load, save };
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -669,6 +669,7 @@ export interface UserProfile {
   preferences?: {
     defaultFill?: FillStyle;
     notificationLevels?: string[];
+    momentumDecay?: number;
   };
 }
 

--- a/src/utils/__tests__/userPreferences.spec.ts
+++ b/src/utils/__tests__/userPreferences.spec.ts
@@ -157,6 +157,56 @@ describe("user preferences utility functions", () => {
         notificationLevels: ["info", "warning"]
       });
     });
+
+    it("should load momentum decay from preferences", async () => {
+      mockUserData["test-user"] = {
+        preferences: {
+          momentumDecay: 20
+        }
+      };
+
+      const result = await loadUserPreferences("test-user");
+      expect(result?.momentumDecay).toBe(20);
+    });
+
+    it("should load momentum decay of 0", async () => {
+      mockUserData["test-user"] = {
+        preferences: {
+          momentumDecay: 0
+        }
+      };
+
+      const result = await loadUserPreferences("test-user");
+      expect(result?.momentumDecay).toBe(0);
+    });
+
+    it("should load momentum decay at maximum value 60", async () => {
+      mockUserData["test-user"] = {
+        preferences: {
+          momentumDecay: 60
+        }
+      };
+
+      const result = await loadUserPreferences("test-user");
+      expect(result?.momentumDecay).toBe(60);
+    });
+
+    it("should load all preferences together", async () => {
+      mockUserData["test-user"] = {
+        preferences: {
+          defaultFill: FillStyle.PlainFill,
+          notificationLevels: ["info", "warning"],
+          momentumDecay: 15
+        }
+      };
+
+      const result = await loadUserPreferences("test-user");
+      expect(result).toEqual({
+        defaultFill: FillStyle.PlainFill,
+        notificationLevels: ["info", "warning"],
+        momentumDecay: 15
+      });
+    });
   });
 
   describe("saveUserPrefs", () => {
@@ -301,6 +351,83 @@ describe("user preferences utility functions", () => {
       const data = mockUserData["test-user"];
       expect(data.preferences.defaultFill).toBe(FillStyle.ShadeFill);
       expect(data.preferences.notificationLevels).toEqual(["error", "warning"]);
+      expect(data.displayName).toBe("Test User");
+    });
+
+    it("should save momentum decay", async () => {
+      await saveUserPreferences("test-user", {
+        momentumDecay: 30
+      });
+
+      const data = mockUserData["test-user"];
+      expect(data).toEqual({
+        preferences: {
+          momentumDecay: 30
+        }
+      });
+    });
+
+    it("should save momentum decay of 0", async () => {
+      await saveUserPreferences("test-user", {
+        momentumDecay: 0
+      });
+
+      const data = mockUserData["test-user"];
+      expect(data).toEqual({
+        preferences: {
+          momentumDecay: 0
+        }
+      });
+    });
+
+    it("should save momentum decay at maximum value 60", async () => {
+      await saveUserPreferences("test-user", {
+        momentumDecay: 60
+      });
+
+      const data = mockUserData["test-user"];
+      expect(data).toEqual({
+        preferences: {
+          momentumDecay: 60
+        }
+      });
+    });
+
+    it("should save all preferences together", async () => {
+      await saveUserPreferences("test-user", {
+        defaultFill: FillStyle.PlainFill,
+        notificationLevels: ["info", "warning"],
+        momentumDecay: 25
+      });
+
+      const data = mockUserData["test-user"];
+      expect(data).toEqual({
+        preferences: {
+          defaultFill: FillStyle.PlainFill,
+          notificationLevels: ["info", "warning"],
+          momentumDecay: 25
+        }
+      });
+    });
+
+    it("should update momentum decay without overwriting other preferences", async () => {
+      mockUserData["test-user"] = {
+        displayName: "Test User",
+        preferences: {
+          defaultFill: FillStyle.ShadeFill,
+          notificationLevels: ["success", "error"],
+          momentumDecay: 10
+        }
+      };
+
+      await saveUserPreferences("test-user", {
+        momentumDecay: 45
+      });
+
+      const data = mockUserData["test-user"];
+      expect(data.preferences.defaultFill).toBe(FillStyle.ShadeFill);
+      expect(data.preferences.notificationLevels).toEqual(["success", "error"]);
+      expect(data.preferences.momentumDecay).toBe(45);
       expect(data.displayName).toBe("Test User");
     });
   });

--- a/src/utils/userPreferences.ts
+++ b/src/utils/userPreferences.ts
@@ -4,6 +4,7 @@ import { FillStyle } from "@/types";
 export type UserPreferences = {
   defaultFill?: FillStyle | null;
   notificationLevels?: string[] | null;
+  momentumDecay?: number | null;
 };
 
 export async function loadUserPreferences(uid: string): Promise<UserPreferences | null> {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -58,6 +58,21 @@
               />
             </v-col>
           </v-row>
+          <v-divider class="my-3" />
+          <h4>Rotation Momentum Decay</h4>
+          <v-row>
+            <v-col cols="6">
+              <v-slider
+                v-model="momentumDecay"
+                :min="0"
+                :max="60"
+                :step="1"
+                label="Decay Time (seconds)"
+                thumb-label
+                @update:modelValue="onMomentumDecayChange"
+              />
+            </v-col>
+          </v-row>
         <!-- Label options temporarily disabled -->
         <!--
         <h3>Label options</h3>
@@ -100,13 +115,18 @@ const prefsStore = useUserPreferencesStore();
 // const imageUpload: Ref<HTMLInputElement | null> = ref(null);
 const decimalPrecision = ref(3);
 const selectedTab = ref(0);
-const profileChanged = ref(false)
+const profileChanged = ref(false);
+const momentumDecay = ref(prefsStore.momentumDecay ?? 0);
 const fillStyleItems = [
   { text: t("noFill"), value: FillStyle.NoFill },
   { text: t("plainFill"), value: FillStyle.PlainFill },
   { text: t("shadeFill"), value: FillStyle.ShadeFill }
 ];
 // The displayed favorite tools (includes defaults)
+function onMomentumDecayChange() {
+  prefsStore.momentumDecay = momentumDecay.value;
+  profileChanged.value = true;
+}
 
 async function doSave(): Promise<void> {
   await acctStore.saveUserProfile();


### PR DESCRIPTION
Added functionality that allows users to specify their momentum decay (0-60 seconds). Defaults to 3 seconds (the previous value). Also added tests for the newly added code